### PR TITLE
Explicitly include StdString.h

### DIFF
--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -1,4 +1,5 @@
 
+#include "kodi/util/StdString.h"
 #include "kodi/util/XMLUtils.h"
 #include "utilities.h"
 


### PR DESCRIPTION
pvr.wmc will fail to compile as soon as the usage of CStdString has been removed from XMLUtils (see https://github.com/xbmc/kodi-platform/pull/2). This will fix it in advance.