### PR TITLE
Minimal support for PVR Addon API 1.9.7

### DIFF
--- a/pvr.wmc/addon.xml
+++ b/pvr.wmc/addon.xml
@@ -6,7 +6,7 @@
   provider-name="KrustyReturns and scarecrow420">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="1.9.6"/>
+    <import addon="xbmc.pvr" version="1.9.7"/>
     <import addon="xbmc.gui" version="5.8.0"/>
   </requires>
   <extension

--- a/pvr.wmc/addon.xml
+++ b/pvr.wmc/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.wmc"
-  version="0.5.6"
+  version="0.6.0"
   name="PVR WMC Client"
   provider-name="KrustyReturns and scarecrow420">
   <requires>

--- a/pvr.wmc/changelog.txt
+++ b/pvr.wmc/changelog.txt
@@ -1,3 +1,6 @@
+v0.6.0
+- Updated to PVR API v1.9.7
+
 0.5.6
 - Updated Language files from Transifex
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -328,7 +328,6 @@ extern "C" {
 		pCapabilities->bSupportsChannelScan			= false;
 		pCapabilities->bHandlesInputStream			= true;
 		pCapabilities->bHandlesDemuxing				= false;
-		pCapabilities->bSupportsRecordingFolders	= false;
 		pCapabilities->bSupportsRecordingPlayCount	= true;
 		pCapabilities->bSupportsLastPlayedPosition	= g_bEnableMultiResume;
 		pCapabilities->bSupportsRecordingEdl		= false;
@@ -439,6 +438,12 @@ extern "C" {
 
 
 	// timer functions
+PVR_ERROR GetTimerTypes(PVR_TIMER_TYPE types[], int *size)
+{
+	/* TODO: Implement this to get support for the timer features introduced with PVR API 1.9.7 */
+	return PVR_ERROR_NOT_IMPLEMENTED;
+}
+
 	int GetTimersAmount(void) 
 	{ 
 		if (_wmc)
@@ -449,6 +454,7 @@ extern "C" {
 
 	PVR_ERROR GetTimers(ADDON_HANDLE handle) 
 	{ 
+		/* TODO: Change implementation to get support for the timer features introduced with PVR API 1.9.7 */
 		if (_wmc)
 			return _wmc->GetTimers(handle);
 
@@ -470,8 +476,10 @@ extern "C" {
 		return PVR_ERROR_NO_ERROR;
 	}
 
-	PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete) 
+	PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool /*bDeleteScheduled*/)
 	{
+	/* TODO: Change implementation to support bDeleteScheduled (introduced with PVR API 1.9.7 */
+
 		if (_wmc)
 			return _wmc->DeleteTimer(timer, bForceDelete);
 		return PVR_ERROR_NO_ERROR;

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -21,5 +21,5 @@
 
 inline CStdString PVRWMC_GetClientVersion()
 {
-	return "0.5.3";	// ALSO CHANGE IN REV NUMBER in 'pvr.wmc/addon.xml' 
+	return "0.6.0";	// ALSO CHANGE IN REV NUMBER in 'pvr.wmc/addon.xml'
 }

--- a/src/pvr2wmc.cpp
+++ b/src/pvr2wmc.cpp
@@ -651,7 +651,7 @@ CStdString Pvr2Wmc::Timer2String(const PVR_TIMER &xTmr)
 
 	tStr.Format("|%d|%d|%d|%d|%d|%s|%d|%d|%d|%d|%d",													// format for 11 params:
 		xTmr.iClientIndex, xTmr.iClientChannelUid, xTmr.startTime, xTmr.endTime, PVR_TIMER_STATE_NEW,		// 5 params
-		xTmr.strTitle, xTmr.iPriority,  xTmr.iMarginStart, xTmr.iMarginEnd, xTmr.bIsRepeating,				// 5 params
+		xTmr.strTitle, xTmr.iPriority,  xTmr.iMarginStart, xTmr.iMarginEnd, xTmr.iWeekdays != PVR_WEEKDAY_NONE,				// 5 params
 		xTmr.iEpgUid);																						// 1 param
 
 	return tStr;
@@ -664,7 +664,7 @@ PVR_ERROR Pvr2Wmc::DeleteTimer(const PVR_TIMER &xTmr, bool bForceDelete)
 
 	bool deleteSeries = false;
 
-	if (xTmr.bIsRepeating)									// if timer is a series timer, ask if want to cancel series
+	if (xTmr.iWeekdays != PVR_WEEKDAY_NONE)									// if timer is a series timer, ask if want to cancel series
 	{
 		CDialogDeleteTimer vWindow(deleteSeries, xTmr.strTitle);
 		int dlogResult = vWindow.DoModal();
@@ -724,6 +724,9 @@ PVR_ERROR Pvr2Wmc::GetTimers(ADDON_HANDLE handle)
 			continue;
 		}
 
+		/* TODO: Implement own timer types to get support for the timer features introduced with PVR API 1.9.7 */
+		xTmr.iTimerType = PVR_TIMER_TYPE_NONE;
+
 		xTmr.iClientIndex = atoi(v[0].c_str());				// timer index (set to same as Entry ID)
 		xTmr.iClientChannelUid = atoi(v[1].c_str());		// channel id
 		xTmr.startTime = atoi(v[2].c_str());                // start time 
@@ -734,7 +737,6 @@ PVR_ERROR Pvr2Wmc::GetTimers(ADDON_HANDLE handle)
 		STRCPY(xTmr.strDirectory, v[6].c_str());			// rec directory
 		STRCPY(xTmr.strSummary, v[7].c_str());				// currently set to episode title
 		xTmr.iPriority = atoi(v[8].c_str());				// rec priority
-		xTmr.bIsRepeating = Str2Bool(v[9].c_str());			// repeating rec (set to series flag)
 
 		xTmr.iEpgUid = atoi(v[10].c_str());					// epg ID (same as client ID, except for a 'manual' record)
 		xTmr.iMarginStart = atoi(v[11].c_str());			// rec margin at start (sec)


### PR DESCRIPTION
For, J**** PVR Addon API will be bumped to version 1.9.7 to introduce a couple of new features and enhancements for timers (esp. official series recording support). => https://github.com/xbmc/xbmc/pull/7079

This PR will ensure compatibility with and add minimalistic support for PVR addon API 1.9.7. Even if the maintainers of this addon will do nothing except merging this PR and bump the addon version in Kodi, the addon will still be usable in J**** and not loose any functionality compared to Isengard, but it will not profit from the new features. For the latter, every addon maintainer must do the respective changes on his own.