### PR TITLE
Bump add-on for PVR API 3.0.0 (Compatibility mode)

### DIFF
--- a/pvr.wmc/addon.xml.in
+++ b/pvr.wmc/addon.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.wmc"
-  version="0.6.3"
+  version="0.6.4"
   name="PVR WMC Client"
   provider-name="KrustyReturns and scarecrow420">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="2.1.0"/>
+    <import addon="xbmc.pvr" version="3.0.0"/>
     <import addon="xbmc.gui" version="5.8.0"/>
   </requires>
   <extension

--- a/pvr.wmc/changelog.txt
+++ b/pvr.wmc/changelog.txt
@@ -1,3 +1,6 @@
+v0.6.4
+- Updated to PVR API v3.0.0
+
 v0.6.3
 - Updated to PVR API v2.1.0
 - Automatically fill in platform and library name

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -21,5 +21,5 @@
 
 inline CStdString PVRWMC_GetClientVersion()
 {
-	return "0.6.1";	// ALSO CHANGE IN REV NUMBER in 'pvr.wmc/addon.xml'
+	return "0.6.4";	// ALSO CHANGE IN REV NUMBER in 'pvr.wmc/addon.xml'
 }


### PR DESCRIPTION
Addon part of https://github.com/xbmc/xbmc/pull/7626
Add on currently using 1.9.7 API compatibility code
No further changes required for minimal support