### PR TITLE
[pvr] Fix Deletion of SeriesTimer

### DIFF
--- a/pvr.wmc/addon.xml.in
+++ b/pvr.wmc/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.wmc"
-  version="0.6.5"
+  version="0.6.6"
   name="PVR WMC Client"
   provider-name="KrustyReturns and scarecrow420">
   <requires>

--- a/pvr.wmc/changelog.txt
+++ b/pvr.wmc/changelog.txt
@@ -1,5 +1,8 @@
+v0.6.6
+- Fix deletion of Series Timers
+
 v0.6.5
-- Implement forst cut of Series Timer support for Kodi 16
+- Implement first cut of Series Timer support for Kodi 16
 
 v0.6.4
 - Updated to PVR API v3.0.0

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -21,5 +21,5 @@
 
 inline CStdString PVRWMC_GetClientVersion()
 {
-	return "0.6.5";	// ALSO CHANGE IN REV NUMBER in 'pvr.wmc/addon.xml.in'
+	return "0.6.6";	// ALSO CHANGE IN REV NUMBER in 'pvr.wmc/addon.xml.in'
 }

--- a/src/pvr2wmc.cpp
+++ b/src/pvr2wmc.cpp
@@ -906,12 +906,11 @@ PVR_ERROR Pvr2Wmc::DeleteTimer(const PVR_TIMER &xTmr, bool bForceDelete, bool bD
 	if (IsServerDown())
 		return PVR_ERROR_SERVER_ERROR;
 
-	CStdString command = "DeleteTimer" + Timer2String(xTmr);
+	bool bRepeating = xTmr.iTimerType >= TIMER_REPEATING_MIN && xTmr.iTimerType <= TIMER_REPEATING_MAX;
 
-	CStdString eStr;										// append whether to delete the series or episode
-	eStr.Format("|%d", bDeleteSchedule);
-	command.append(eStr);
-
+	CStdString command = "DeleteTimerKodi";
+	command.Format("DeleteTimerKodi|%d|%d|%d", xTmr.iClientIndex, bRepeating, bDeleteSchedule);
+	
 	vector<CStdString> results = _socketClient.GetVector(command, false);	// get results from server
 
 	PVR->TriggerTimerUpdate();									// update timers regardless of whether there is an error


### PR DESCRIPTION
Call new backend method DeleteTimerKodi() and pass appropriate fields.
Fixes deletion of series timers