### PR TITLE
[pvr] PVR API 4.0 changes

### DIFF
--- a/pvr.wmc/addon.xml.in
+++ b/pvr.wmc/addon.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.wmc"
-  version="0.6.6"
+  version="0.6.7"
   name="PVR WMC Client"
   provider-name="KrustyReturns and scarecrow420">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="3.0.0"/>
+    <import addon="xbmc.pvr" version="4.0.0"/>
     <import addon="xbmc.gui" version="5.8.0"/>
   </requires>
   <extension

--- a/pvr.wmc/changelog.txt
+++ b/pvr.wmc/changelog.txt
@@ -1,3 +1,6 @@
+v0.6.7
+- Updated to PVR API v4.0.0
+
 v0.6.6
 - Fix deletion of Series Timers
 
@@ -117,7 +120,7 @@ v0.6.0
 - better updating of ‘Recordings’ list for all client platforms
 - can receive gui update triggers from server when checking server status
 - AddTimer notifications are now info/warning rather than errors
-- Add workaround to get XBMC skip/seek to behave nicely for Active and Remuxed recordings 
+- Add workaround to get XBMC skip/seek to behave nicely for Active and Remuxed recordings
 
 0.2.93
 - Implements channel groups
@@ -128,11 +131,11 @@ v0.6.0
 - Supports resume across multiple clients (gotham only)
 - Receives and parses server version
 - Signal status can be scanned (note requires enabling in pvr.wmc addon configuration – gotham clients only
- 
+
 0.2.91
 - Changed some message strings, added message for instant record
 - Gotham only: updated pvr interface to xbmc 1.9.0, to work with newest gotham builds
- 
+
 0.2.9
 - Fixed skin folder name so xml files no longer need to be placed in xbmc install folder (confluence only)
 - Gotham only: fixed custom dialogs
@@ -143,13 +146,13 @@ v0.6.0
 - Client now posts stream open errors to server
 - Increase wait interval for streamfile size check
 - Credential password hidden from log
- 
-0.1.8 
+
+0.1.8
 - Fixed bug that could make client give up on live streams intermittently
 - Stopped freezing/crashing when live-tv tuner is stolen for a recording
 - Now knows whether a stream is actively growing
 - Build number reported to server app
- 
+
 0.1.7
  - made StreamSize server queries happen less often
  - fixed ‘vector’ class connection crashes when socket is not available

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -478,10 +478,10 @@ extern "C" {
 		return PVR_ERROR_NO_ERROR;
 	}
 
-	PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool bDeleteScheduled)
+	PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete)
 	{
 		if (_wmc)
-			return _wmc->DeleteTimer(timer, bForceDelete, bDeleteScheduled);
+			return _wmc->DeleteTimer(timer, bForceDelete);
 		return PVR_ERROR_NO_ERROR;
 	}
 

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -21,5 +21,5 @@
 
 inline CStdString PVRWMC_GetClientVersion()
 {
-	return "0.6.6";	// ALSO CHANGE IN REV NUMBER in 'pvr.wmc/addon.xml.in'
+	return "0.6.7";	// ALSO CHANGE IN REV NUMBER in 'pvr.wmc/addon.xml.in'
 }

--- a/src/pvr2wmc.cpp
+++ b/src/pvr2wmc.cpp
@@ -901,7 +901,7 @@ CStdString Pvr2Wmc::Timer2String(const PVR_TIMER &xTmr)
 	return tStr;
 }
 
-PVR_ERROR Pvr2Wmc::DeleteTimer(const PVR_TIMER &xTmr, bool bForceDelete, bool bDeleteSchedule)
+PVR_ERROR Pvr2Wmc::DeleteTimer(const PVR_TIMER &xTmr, bool bForceDelete)
 {
 	if (IsServerDown())
 		return PVR_ERROR_SERVER_ERROR;
@@ -909,7 +909,7 @@ PVR_ERROR Pvr2Wmc::DeleteTimer(const PVR_TIMER &xTmr, bool bForceDelete, bool bD
 	bool bRepeating = xTmr.iTimerType >= TIMER_REPEATING_MIN && xTmr.iTimerType <= TIMER_REPEATING_MAX;
 
 	CStdString command = "DeleteTimerKodi";
-	command.Format("DeleteTimerKodi|%d|%d|%d", xTmr.iClientIndex, bRepeating, bDeleteSchedule);
+	command.Format("DeleteTimerKodi|%d|%d", xTmr.iClientIndex, bRepeating);
 	
 	vector<CStdString> results = _socketClient.GetVector(command, false);	// get results from server
 
@@ -921,10 +921,7 @@ PVR_ERROR Pvr2Wmc::DeleteTimer(const PVR_TIMER &xTmr, bool bForceDelete, bool bD
 	}
 	else
 	{
-		if (bDeleteSchedule)
-			XBMC->Log(LOG_DEBUG, "deleted series timer '%s', with rec state %s", xTmr.strTitle, results[0].c_str());
-		else
-			XBMC->Log(LOG_DEBUG, "deleted timer '%s', with rec state %s", xTmr.strTitle, results[0].c_str());
+		XBMC->Log(LOG_DEBUG, "deleted timer '%s', with rec state %s", xTmr.strTitle, results[0].c_str());
 		return PVR_ERROR_NO_ERROR;
 	}
 }

--- a/src/pvr2wmc.h
+++ b/src/pvr2wmc.h
@@ -99,7 +99,7 @@ public:
 	// timers
 	virtual PVR_ERROR GetTimers(ADDON_HANDLE handle);
 	virtual PVR_ERROR AddTimer(const PVR_TIMER &timer);
-	virtual PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool bDeleteSchedule);
+	virtual PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete);
 	virtual int GetTimersAmount(void);
 
 	// recording files


### PR DESCRIPTION
Changes for compatibility with PVR API 4.0

- Removal of bDeleteScheduled member in DeleteTimer

This PR cannot be merged until the Kodi side change is in https://github.com/xbmc/xbmc/pull/8005