### PR TITLE
[pvr] Fix for manual timers created from guide

### DIFF
--- a/pvr.wmc/addon.xml.in
+++ b/pvr.wmc/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.wmc"
-  version="0.6.8"
+  version="0.6.9"
   name="PVR WMC Client"
   provider-name="KrustyReturns and scarecrow420">
   <requires>

--- a/pvr.wmc/changelog.txt
+++ b/pvr.wmc/changelog.txt
@@ -1,3 +1,6 @@
+v0.6.9
+- fix for manual timers created from EPG showing as guide based timers
+
 v0.6.8
 - Updated to PVR API v4.1.0
 - Populate IsSeries field on EPG Items

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -21,5 +21,5 @@
 
 inline CStdString PVRWMC_GetClientVersion()
 {
-	return "0.6.8";	// ALSO CHANGE IN REV NUMBER in 'pvr.wmc/addon.xml.in'
+	return "0.6.9";	// ALSO CHANGE IN REV NUMBER in 'pvr.wmc/addon.xml.in'
 }

--- a/src/pvr2wmc.cpp
+++ b/src/pvr2wmc.cpp
@@ -895,6 +895,7 @@ CStdString Pvr2Wmc::Timer2String(const PVR_TIMER &xTmr)
 
 	bool bRepeating = xTmr.iTimerType >= TIMER_REPEATING_MIN && xTmr.iTimerType <= TIMER_REPEATING_MAX;
 	bool bKeyword = xTmr.iTimerType == TIMER_REPEATING_KEYWORD || xTmr.iTimerType == TIMER_ONCE_KEYWORD || xTmr.iTimerType == TIMER_ONCE_KEYWORD_CHILD;
+	bool bManual = xTmr.iTimerType == TIMER_ONCE_MANUAL || xTmr.iTimerType == TIMER_ONCE_MANUAL_CHILD || xTmr.iTimerType == TIMER_REPEATING_MANUAL;
 
 	tStr.Format("|%d|%d|%d|%d|%d|%s|%d|%d|%d|%d|%d",
 		xTmr.iClientIndex, xTmr.iClientChannelUid, xTmr.startTime, xTmr.endTime, PVR_TIMER_STATE_NEW,		// 0-4
@@ -903,9 +904,9 @@ CStdString Pvr2Wmc::Timer2String(const PVR_TIMER &xTmr)
 
 	// Append extra fields from Kodi 16
 	CStdString extra;
-	extra.Format("|%d|%d|%d|%d|%d|%d|%s|%d",
+	extra.Format("|%d|%d|%d|%d|%d|%d|%s|%d|%d",
 		xTmr.iPreventDuplicateEpisodes, xTmr.bStartAnyTime, xTmr.iWeekdays, // 11-13 param
-		xTmr.iLifetime, bKeyword, xTmr.bFullTextEpgSearch, xTmr.strEpgSearchString, xTmr.iMaxRecordings); // 14-18
+		xTmr.iLifetime, bKeyword, xTmr.bFullTextEpgSearch, xTmr.strEpgSearchString, xTmr.iMaxRecordings, bManual); // 14-19
 	tStr.append(extra);
 
 	return tStr;


### PR DESCRIPTION
When creating a custom timer from the Guide, and changing Timer Type to one of the Manual options, the EPG ID is still set, resulting in ServerWMC creating a guide based timer rather than manual timer.  We now send a boolean to specify ManualRecord is required