### PR TITLE
Populate new Recording::ChannelUid field added in API 5.0.0

### DIFF
--- a/pvr.wmc/addon.xml.in
+++ b/pvr.wmc/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.wmc"
-  version="1.1.0"
+  version="1.1.1"
   name="PVR WMC Client"
   provider-name="KrustyReturns and scarecrow420">
   <requires>

--- a/pvr.wmc/changelog.txt
+++ b/pvr.wmc/changelog.txt
@@ -1,3 +1,6 @@
+1.1.1
+- Populate Channel UID field on recordings
+
 1.1.0
 - Updated to PVR addon API v5.0.0
 

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -21,5 +21,5 @@
 
 inline CStdString PVRWMC_GetClientVersion()
 {
-	return "1.1.0";	// ALSO CHANGE IN REV NUMBER in 'pvr.wmc/addon.xml.in'
+	return "1.1.1";	// ALSO CHANGE IN REV NUMBER in 'pvr.wmc/addon.xml.in'
 }

--- a/src/pvr2wmc.cpp
+++ b/src/pvr2wmc.cpp
@@ -1142,8 +1142,15 @@ PVR_ERROR Pvr2Wmc::GetRecordings(ADDON_HANDLE handle)
 			xRec.iEpgEventId = atoi(v[18].c_str());
 		}
 
-		/* TODO: PVR API 5.0.0: Implement this */
-		xRec.iChannelUid = PVR_CHANNEL_INVALID_UID;
+		// Kodi PVR API 5.0.0 adds EPG ID field
+		if (v.size() > 18)
+		{
+			xRec.iChannelUid = atoi(v[17].c_str());
+		}
+		else
+		{
+			xRec.iChannelUid = PVR_CHANNEL_INVALID_UID;
+		}
 
 		PVR->TransferRecordingEntry(handle, &xRec);
 	}


### PR DESCRIPTION
Now that #36 is in, we can populate the new field on Recordings