### PR TITLE
Fix conflict with pvr-hts

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,8 +10,6 @@ Package: kodi-pvr-wmc
 Section: libs
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Conflicts: kodi-pvr-tvheadend-hts
-Replaces: kodi-pvr-tvheadend-hts
 Description: WMC PVR for Kodi
  WMC PVR for Kodi
 


### PR DESCRIPTION
Fixes #60 by cherry-picking [`0c59136`](https://github.com/kodi-pvr/pvr.wmc/commit/0c591368ed96333e2dab594f18bd7530056f8512) (credit to @diogomsantos) from `master` and applying it to `Krypton`.

Hope it looks OK.