### PR TITLE
src/utilities.h: add cstdarg include

### DIFF
--- a/pvr.wmc/addon.xml.in
+++ b/pvr.wmc/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.wmc"
-  version="5.0.0"
+  version="5.0.1"
   name="PVR WMC Client"
   provider-name="KrustyReturns and scarecrow420">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.wmc/changelog.txt
+++ b/pvr.wmc/changelog.txt
@@ -1,3 +1,6 @@
+5.0.1
+- src/utilities.h: add cstdarg include
+
 5.0.0
 - PVR API 7.0.0
 - Rework addon to support new API interface

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -10,6 +10,7 @@
 
 #include "stdio.h"
 
+#include <cstdarg>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Fixes build error with gcc 8.3.0:

src/utilities.h:24:38: error: ‘va_list’ has not been declared
 std::string FormatV(const char* fmt, va_list args);