### PR TITLE
[Nexus] Add supports recordings delete capability for PVR API 8.0.0

### DIFF
--- a/pvr.wmc/addon.xml.in
+++ b/pvr.wmc/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.wmc"
-  version="20.0.0"
+  version="20.1.0"
   name="PVR WMC Client"
   provider-name="KrustyReturns and scarecrow420">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.wmc/changelog.txt
+++ b/pvr.wmc/changelog.txt
@@ -1,3 +1,8 @@
+v20.1.0
+- Kodi PVR API to 8.0.0
+  - Add supports recordings delete capability
+  - Enforce EDL limits
+
 v20.0.0
 - Translations updates from Weblate
   - da_dk, ko_kr, ml_in, pl_pl

--- a/src/pvr2wmc.cpp
+++ b/src/pvr2wmc.cpp
@@ -52,6 +52,7 @@ PVR_ERROR Pvr2Wmc::GetCapabilities(kodi::addon::PVRCapabilities& capabilities)
   capabilities.SetSupportsTV(true);
   capabilities.SetSupportsRadio(true);
   capabilities.SetSupportsRecordings(true);
+  capabilities.SetSupportsRecordingsDelete(true);
   capabilities.SetSupportsRecordingsUndelete(false);
   capabilities.SetSupportsTimers(true);
   capabilities.SetSupportsChannelGroups(true);


### PR DESCRIPTION
- Kodi API to 8.0.0
  - Following in API change (not all affect addon):
    - Add supports recordings delete capability
    - Add support for PVR Providers and parental rating code for EPG
    - Enforce EDL limits

This PR should be rebuilt via Jenkins after these xbmc PRs are merged:
- https://github.com/xbmc/xbmc/pull/20009
- https://github.com/xbmc/xbmc/pull/19395